### PR TITLE
feat: add PID parameters and update SERIAL_Handler for control gains

### DIFF
--- a/Plane/Core/Inc/FC_Serial/MiniLink/MiniLink.h
+++ b/Plane/Core/Inc/FC_Serial/MiniLink/MiniLink.h
@@ -46,6 +46,7 @@ typedef struct __attribute__((packed)){
 	PARAM_RC rc;
 	PARAM_SERIAL serial[4];
 	PARAM_SERVO servo;
+	PARAM_PID pid;
 } PARAM;
 
 extern PARAM param;

--- a/Plane/Core/Inc/FC_Serial/MiniLink/Param/Param_type.h
+++ b/Plane/Core/Inc/FC_Serial/MiniLink/Param/Param_type.h
@@ -95,4 +95,26 @@ typedef struct __attribute__((packed)){
 } PARAM_SERVO;
 
 
+/* PID -----------------------------------------------------------------------*/
+typedef struct __attribute__((packed)){
+    float ANGLE_ROLL_KP;
+    float ANGLE_ROLL_KI;
+    float ANGLE_ROLL_KD;
+    float ANGLE_PITCH_KP;
+    float ANGLE_PITCH_KI;
+    float ANGLE_PITCH_KD;
+    float ANGLE_YAW_KP;
+    float ANGLE_YAW_KI;
+    float ANGLE_YAW_KD;
+    float RATE_ROLL_KP;
+    float RATE_ROLL_KI;
+    float RATE_ROLL_KD;
+    float RATE_PITCH_KP;
+    float RATE_PITCH_KI;
+    float RATE_PITCH_KD;
+    float RATE_YAW_KP;
+    float RATE_YAW_KI;
+    float RATE_YAW_KD;
+} PARAM_PID;
+
 #endif /* INC_FC_PARAM_PARAM_TYPE_H_ */

--- a/Plane/Core/Src/FC_Serial/Serial.c
+++ b/Plane/Core/Src/FC_Serial/Serial.c
@@ -71,6 +71,48 @@ int SERIAL_Handler()
 		msg.scaled_pressure.press_diff = tmp[1];
 
 		break;
+	case 250:
+        // 메시지로 한 번에 전달할 수 있는 데이터의 개수가 14개임
+        // 일단 임시로 9개로 나눠서 작성
+        // 추후 원인 분석해서 개선 필요
+
+        float *tmp2 = (float*)serialRX.payload;
+        
+        // 외부 제어기(각도) 제어 이득 설정
+        param.pid.ANGLE_ROLL_KP = tmp2[0];
+        param.pid.ANGLE_ROLL_KI = tmp2[1];
+        param.pid.ANGLE_ROLL_KD = tmp2[2];
+        param.pid.ANGLE_PITCH_KP = tmp2[3];
+        param.pid.ANGLE_PITCH_KI = tmp2[4];
+        param.pid.ANGLE_PITCH_KD = tmp2[5];
+        param.pid.ANGLE_YAW_KP = tmp2[6];
+        param.pid.ANGLE_YAW_KI = tmp2[7];
+        param.pid.ANGLE_YAW_KD = tmp2[8];
+        
+        // 임시 확인용
+        msg.scaled_pressure.time_boot_ms= serialRX.header.length;
+        msg.scaled_pressure.press_abs = param.pid.ANGLE_YAW_KD;
+        
+        break;
+    case 251:
+        float *tmp3 = (float*)serialRX.payload;
+        
+        // 내부 제어기(각속도) 제어 이득 설정
+        param.pid.RATE_ROLL_KP = tmp3[0];
+        param.pid.RATE_ROLL_KI = tmp3[1];
+        param.pid.RATE_ROLL_KD = tmp3[2];
+        param.pid.RATE_PITCH_KP = tmp3[3];
+        param.pid.RATE_PITCH_KI = tmp3[4];
+        param.pid.RATE_PITCH_KD = tmp3[5];
+        param.pid.RATE_YAW_KP = tmp3[6];
+        param.pid.RATE_YAW_KI = tmp3[7];
+        param.pid.RATE_YAW_KD = tmp3[8];
+        
+        // 임시 확인용
+        msg.scaled_pressure.time_boot_ms= serialRX.header.length;
+        msg.scaled_pressure.press_diff = param.pid.RATE_YAW_KD;
+        
+        break;
 	}
 
 	return 0;


### PR DESCRIPTION
### 추가 사항
- Param에 PID 계수 추가
- 250번 메시지를 통해 각도 제어기 계수 설정 가능
- 251번 메시지를 통해 각속도 제어기 계수 설정 가능

### 추후 조치
- 현재는 18개의 실수를 한 번에 보낼 수 없음 (14개 최대, 디버깅 필요)
- 23번 PARAM_SET 메시지를 통해 설정하도록 변경 필요